### PR TITLE
load-graph.sh now runs convert script when either binary is missing

### DIFF
--- a/bin/sh/load-graph.sh
+++ b/bin/sh/load-graph.sh
@@ -60,7 +60,7 @@ else
 fi
 
 # convert .mtx/.vtx files to binary .vtb/.grb files
-if [[ ! -f ${OUTPUT_PATH}/graph.vtb && ! -f ${OUTPUT_PATH}/graph.grb ]]; then
+if [[ ! -f ${OUTPUT_PATH}/graph.vtb || ! -f ${OUTPUT_PATH}/graph.grb ]]; then
     bin/exe/converter --data-dir ${OUTPUT_PATH}
 else
     echo "Transformed binary files (grb/vtb) already exist, no conversion required"


### PR DESCRIPTION
Benchmark was segfaulting when intermediate/*/graph.grb was missing, but graph.vtb was not.  

Benchmark still fails when graph.grb becomes size 0, due to some failing or aborted conversion. That can now be fixed by running
> find intermediate/ -name "graph.grb" -size 0 -delete